### PR TITLE
Extract mutation & request utility from middleware

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
 
     # python code formatting - will amend files
     - repo: https://github.com/ambv/black
-      rev: 19.10b0
+      rev: 20.8b1
       hooks:
           - id: black
             language_version: python3.7

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest, HttpResponse
@@ -35,21 +34,6 @@ class TestUtmSessionMiddleware:
 
 
 class TestLeadSourceMiddleware:
-    @pytest.mark.parametrize(
-        "medium,source,result",
-        (
-            ("", "", False),
-            ("foo", "", False),
-            ("", "bar", False),
-            ("foo", "bar", True),
-        ),
-    )
-    def test_has_utm(self, medium, source, result):
-        request = mock.Mock(spec=HttpRequest)
-        request.session = {"utm_medium": medium, "utm_source": source}
-        middleware = LeadSourceMiddleware(lambda r: HttpResponse())
-        assert middleware.has_utm(request) == result
-
     @pytest.mark.django_db
     def test_capture_lead_source(self):
         user = User.objects.create(username="Bob")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,6 @@ from django.http import HttpRequest
 
 from utm_tracker.models import LeadSource
 
-
 User = get_user_model()
 
 
@@ -23,8 +22,10 @@ class TestLeadSourceManager:
             "utm_content": "content",
         }
 
-        LeadSource.objects.create_from_request(user=user, request=request)
+        ls_returned = LeadSource.objects.create_from_request(user=user, request=request)
+
         ls = LeadSource.objects.get()
+        assert ls == ls_returned
 
         assert ls.user == user
         assert ls.medium == "medium"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,36 @@
+from unittest import mock
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.http import HttpRequest
+
+from utm_tracker.models import LeadSource
+
+
+User = get_user_model()
+
+
+class TestLeadSourceManager:
+    @pytest.mark.django_db
+    def test_create_from_request(self):
+        user = User.objects.create(username="Bob")
+        request = mock.Mock(spec=HttpRequest, user=user)
+        request.session = {
+            "utm_medium": "medium",
+            "utm_source": "source",
+            "utm_campaign": "campaign",
+            "utm_term": "term",
+            "utm_content": "content",
+        }
+
+        LeadSource.objects.create_from_request(user=user, request=request)
+        ls = LeadSource.objects.get()
+
+        assert ls.user == user
+        assert ls.medium == "medium"
+        assert ls.source == "source"
+        assert ls.campaign == "campaign"
+        assert ls.term == "term"
+        assert ls.content == "content"
+        # Ensure we have cleared out the session
+        assert request.session == {}

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,53 @@
+from unittest import mock
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpRequest, HttpResponse
+from django.test import Client
+
+from utm_tracker.request import request_has_utm_params
+
+User = get_user_model()
+
+
+class TestRequestHasUtmParams:
+    @pytest.mark.parametrize(
+        "utm_medium,utm_source,result",
+        (
+            ("", "", False),
+            ("foo", "", False),
+            ("", "bar", False),
+            ("foo", "bar", True),
+        ),
+    )
+    def with_default_required_params(self, utm_medium, utm_source, result):
+        request = mock.Mock(spec=HttpRequest)
+        request.session = {"utm_medium": utm_medium, "utm_source": utm_source}
+        assert request_has_utm_params(request) == result
+
+    @pytest.mark.parametrize(
+        "utm_medium,utm_source,utm_content,result",
+        (
+            ("", "", "", False),
+            ("foo", "", "", False),
+            ("foo", "", "car", False),
+            ("", "bar", "", False),
+            ("foo", "bar", "", False),
+            ("", "", "car", False),
+            ("foo", "bar", "car", True),
+        ),
+    )
+    def with_passed_required_params(self, utm_medium, utm_source, utm_content, result):
+        request = mock.Mock(spec=HttpRequest)
+        request.session = {
+            "utm_medium": utm_medium,
+            "utm_source": utm_source,
+            "utm_content": utm_content,
+        }
+        assert (
+            request_has_utm_params(
+                request, required_params=["utm_medium", "utm_source", "utm_content"]
+            )
+            == result
+        )

--- a/utm_tracker/models.py
+++ b/utm_tracker/models.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
+from typing import Type
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
+from django.db.models.base import Model
 from django.http import HttpRequest
 from django.utils import timezone
-
 
 User = get_user_model()
 
 
 class LeadSourceManager(models.Manager):
-    def create_from_request(self, user: User, request: HttpRequest) -> LeadSource:
+    def create_from_request(
+        self, user: Type[Model], request: HttpRequest
+    ) -> LeadSource:
         """
         Persist a LeadSource from an inbound HTTP Request.
 
@@ -23,7 +27,7 @@ class LeadSourceManager(models.Manager):
         sometimes we want to persist a LeadSource against a known user from
         an unauthenticated request.
         """
-        LeadSource.objects.create(
+        return LeadSource.objects.create(
             user=user,
             medium=request.session.pop("utm_medium"),
             source=request.session.pop("utm_source"),

--- a/utm_tracker/models.py
+++ b/utm_tracker/models.py
@@ -72,7 +72,9 @@ class LeadSource(models.Model):
     """
 
     user = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="lead_sources",
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="lead_sources",
     )
     medium = models.CharField(
         max_length=10,

--- a/utm_tracker/request.py
+++ b/utm_tracker/request.py
@@ -1,0 +1,19 @@
+from django.http import HttpRequest
+
+
+def request_has_utm_params(request: HttpRequest, required_params=None) -> bool:
+    """
+    Return True if the request has UTM paramaters we consider valid.
+
+    This function should be called before automatically persisting a
+    LeadSource, to ensure that one is only persisted when enough valid
+    UTM parameters exist for it to make sense.
+
+    The `required_params` parameter can be overriden on a per-call basis to
+    decide which parameters should be required for a given call. We provide
+    a sane default.
+    """
+    required_params = required_params or ["utm_source", "utm_medium"]
+
+    required_values = [request.session.get(param, "") for param in required_params]
+    return all(required_values)

--- a/utm_tracker/request.py
+++ b/utm_tracker/request.py
@@ -1,7 +1,11 @@
+from typing import List
+
 from django.http import HttpRequest
 
 
-def request_has_utm_params(request: HttpRequest, required_params=None) -> bool:
+def request_has_utm_params(
+    request: HttpRequest, required_params: List[str] = None
+) -> bool:
     """
     Return True if the request has UTM paramaters we consider valid.
 


### PR DESCRIPTION
In our calling code we have a need to persist a LeadSource
manually when a user is not authenticated and we know this
can be considered reliable.

But before this change, we would have had to write custom
code rather than importing functions from this library as
the "working logic" was hidden inside middleware methods.

This PR moves two things outside of the middleware, so that
they can be called from elsewhere - and updates the middleware
to make that same call.

1) The "has the request got the utm params we want?" utility.

2) The "persist the lead source and clear the session" function.