### PR TITLE
Add support for multiple lead sources in a single session

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 88
 max-complexity = 8
-exclude = tests,migrations
+exclude = tests,migrations,.venv
 # http://flake8.pycqa.org/en/2.5.5/warnings.html#warning-error-codes
 ignore =
   # pydocstyle - docstring conventions (PEP257)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -46,7 +46,7 @@ class TestUtmSessionMiddleware:
 
 
 class TestLeadSourceMiddleware:
-    @mock.patch("utm_tracker.middleware.flush_utm_params")
+    @mock.patch("utm_tracker.middleware.dump_utm_params")
     def test_middleware__unauthenticated(self, mock_flush):
         request = mock.Mock(spec=HttpRequest, user=AnonymousUser())
         assert not request.user.is_authenticated
@@ -54,7 +54,7 @@ class TestLeadSourceMiddleware:
         middleware(request)
         assert mock_flush.call_count == 0
 
-    @mock.patch("utm_tracker.middleware.flush_utm_params")
+    @mock.patch("utm_tracker.middleware.dump_utm_params")
     def test_middleware__authenticated(self, mock_flush):
         session = mock.Mock(SessionBase)
         request = mock.Mock(spec=HttpRequest, user=User(), session=session)
@@ -63,7 +63,7 @@ class TestLeadSourceMiddleware:
         assert mock_flush.call_count == 1
         mock_flush.assert_called_once_with(request.user, session)
 
-    @mock.patch("utm_tracker.middleware.flush_utm_params")
+    @mock.patch("utm_tracker.middleware.dump_utm_params")
     def test_middleware__error(self, mock_flush):
         session = mock.Mock(SessionBase)
         request = mock.Mock(spec=HttpRequest, user=User(), session=session)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,53 +1,39 @@
 from unittest import mock
 
-import pytest
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
-from django.http import HttpRequest, HttpResponse
-from django.test import Client
+from django.http import HttpRequest
 
-from utm_tracker.request import request_has_utm_params
-
-User = get_user_model()
+from utm_tracker.request import parse_qs
 
 
-class TestRequestHasUtmParams:
-    @pytest.mark.parametrize(
-        "utm_medium,utm_source,result",
-        (
-            ("", "", False),
-            ("foo", "", False),
-            ("", "bar", False),
-            ("foo", "bar", True),
-        ),
-    )
-    def with_default_required_params(self, utm_medium, utm_source, result):
-        request = mock.Mock(spec=HttpRequest)
-        request.session = {"utm_medium": utm_medium, "utm_source": utm_source}
-        assert request_has_utm_params(request) == result
+def test_pars_qs__ignores_non_utm():
+    request = mock.Mock(spec=HttpRequest)
+    request.GET = {
+        "utm_source": "source",
+        "utm_medium": "medium",
+        "utm_campaign": "campaign",
+        "utm_term": "term",
+        "utm_content": "content",
+        "foo": "bar",
+    }
+    assert parse_qs(request) == {
+        "utm_source": "source",
+        "utm_medium": "medium",
+        "utm_campaign": "campaign",
+        "utm_term": "term",
+        "utm_content": "content",
+    }
 
-    @pytest.mark.parametrize(
-        "utm_medium,utm_source,utm_content,result",
-        (
-            ("", "", "", False),
-            ("foo", "", "", False),
-            ("foo", "", "car", False),
-            ("", "bar", "", False),
-            ("foo", "bar", "", False),
-            ("", "", "car", False),
-            ("foo", "bar", "car", True),
-        ),
-    )
-    def with_passed_required_params(self, utm_medium, utm_source, utm_content, result):
-        request = mock.Mock(spec=HttpRequest)
-        request.session = {
-            "utm_medium": utm_medium,
-            "utm_source": utm_source,
-            "utm_content": utm_content,
-        }
-        assert (
-            request_has_utm_params(
-                request, required_params=["utm_medium", "utm_source", "utm_content"]
-            )
-            == result
-        )
+
+def test_pars_qs__ignores_empty_fields():
+    request = mock.Mock(spec=HttpRequest)
+    request.GET = {
+        "utm_source": "source",
+        "utm_medium": "medium",
+        "utm_campaign": "",
+        "utm_term": "",
+        "utm_content": "",
+    }
+    assert parse_qs(request) == {
+        "utm_source": "source",
+        "utm_medium": "medium",
+    }

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,57 @@
+from utm_tracker.models import LeadSource
+import pytest
+from django.contrib.auth import get_user_model
+
+from utm_tracker.session import SESSION_KEY_UTM_PARAMS, flush_utm_params, stash_utm_params
+
+User = get_user_model()
+
+
+def test_stash_utm_params():
+    session = {}
+    assert not stash_utm_params(session, {})
+
+    assert stash_utm_params(session, {"utm_medium": "foo"})
+    assert len(session[SESSION_KEY_UTM_PARAMS]) == 1
+    assert session[SESSION_KEY_UTM_PARAMS][0] == {"utm_medium": "foo"}
+
+    # add a second set of params
+    assert stash_utm_params(session, {"utm_medium": "bar"})
+    assert len(session[SESSION_KEY_UTM_PARAMS]) == 2
+    assert session[SESSION_KEY_UTM_PARAMS][1] == {"utm_medium": "bar"}
+
+
+@pytest.mark.django_db
+def test_flush_utm_params():
+    user = User.objects.create()
+    utm_params1 = {"utm_medium": "medium1", "utm_source": "source1"}
+    utm_params2 = {"utm_medium": "medium2", "utm_source": "source2"}
+    session = {
+        SESSION_KEY_UTM_PARAMS: [utm_params1, utm_params2]
+    }
+    created = flush_utm_params(user, session)
+    assert LeadSource.objects.count() == 2
+    first = LeadSource.objects.first()
+    last = LeadSource.objects.last()
+    assert first.medium == 'medium1'
+    assert last.medium == 'medium2'
+    assert created == [first, last]
+
+
+@pytest.mark.django_db
+def test_flush_utm_params__error():
+    """Check that if one utm_params fail, others continue."""
+    user = User.objects.create()
+    utm_params1 = {"utm_mediumx": "medium1", "utm_source": "source1"}
+    utm_params2 = {"utm_medium": "medium2", "utm_source": "source2"}
+    session = {
+        SESSION_KEY_UTM_PARAMS: [utm_params1, utm_params2]
+    }
+    created = flush_utm_params(user, session)
+    # only one object will be stored
+    source = LeadSource.objects.get()
+    assert source.medium == 'medium2'
+    assert created == [source]
+    # session is clean
+    assert SESSION_KEY_UTM_PARAMS not in session
+

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,7 +2,7 @@ from utm_tracker.models import LeadSource
 import pytest
 from django.contrib.auth import get_user_model
 
-from utm_tracker.session import SESSION_KEY_UTM_PARAMS, flush_utm_params, stash_utm_params
+from utm_tracker.session import SESSION_KEY_UTM_PARAMS, dump_utm_params, stash_utm_params
 
 User = get_user_model()
 
@@ -22,14 +22,14 @@ def test_stash_utm_params():
 
 
 @pytest.mark.django_db
-def test_flush_utm_params():
+def test_dump_utm_params():
     user = User.objects.create()
     utm_params1 = {"utm_medium": "medium1", "utm_source": "source1"}
     utm_params2 = {"utm_medium": "medium2", "utm_source": "source2"}
     session = {
         SESSION_KEY_UTM_PARAMS: [utm_params1, utm_params2]
     }
-    created = flush_utm_params(user, session)
+    created = dump_utm_params(user, session)
     assert LeadSource.objects.count() == 2
     first = LeadSource.objects.first()
     last = LeadSource.objects.last()
@@ -39,7 +39,7 @@ def test_flush_utm_params():
 
 
 @pytest.mark.django_db
-def test_flush_utm_params__error():
+def test_dump_utm_params__error():
     """Check that if one utm_params fail, others continue."""
     user = User.objects.create()
     utm_params1 = {"utm_mediumx": "medium1", "utm_source": "source1"}
@@ -47,7 +47,7 @@ def test_flush_utm_params__error():
     session = {
         SESSION_KEY_UTM_PARAMS: [utm_params1, utm_params2]
     }
-    created = flush_utm_params(user, session)
+    created = dump_utm_params(user, session)
     # only one object will be stored
     source = LeadSource.objects.get()
     assert source.medium == 'medium2'

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,8 +1,11 @@
 from django.contrib import admin
 from django.urls import path
 
+from .views import test_view
+
 admin.autodiscover()
 
 urlpatterns = [
+    path("", test_view),
     path("admin/", admin.site.urls),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,0 +1,7 @@
+from django.http import HttpRequest, HttpResponse
+
+
+def test_view(request: HttpRequest) -> HttpResponse:
+    request.session.setdefault("foo", 0)
+    request.session["foo"] += 1
+    return HttpResponse("OK")

--- a/utm_tracker/middleware.py
+++ b/utm_tracker/middleware.py
@@ -4,7 +4,7 @@ from typing import Callable
 from django.http import HttpRequest, HttpResponse
 
 from .request import parse_qs
-from .session import flush_utm_params, stash_utm_params
+from .session import dump_utm_params, stash_utm_params
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class LeadSourceMiddleware:
     def __call__(self, request: HttpRequest) -> HttpResponse:
         if request.user.is_authenticated:
             try:
-                flush_utm_params(request.user, request.session)
+                dump_utm_params(request.user, request.session)
             except:  # noqa E722
                 logger.exception("Error flushing utm_params from request")
 

--- a/utm_tracker/models.py
+++ b/utm_tracker/models.py
@@ -3,38 +3,29 @@ from __future__ import annotations
 from typing import Type
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.models.base import Model
-from django.http import HttpRequest
 from django.utils import timezone
 
-User = get_user_model()
+from .types import UtmParamsDict
 
 
 class LeadSourceManager(models.Manager):
-    def create_from_request(
-        self, user: Type[Model], request: HttpRequest
+    def create_from_utm_params(
+        self, user: Type[Model], utm_params: UtmParamsDict
     ) -> LeadSource:
-        """
-        Persist a LeadSource from an inbound HTTP Request.
-
-        This method 'pop's the values from the Django Session deliberately,
-        so that when a LeadSource is persisted - the session is cleared. This
-        is so we do not persist a new LeadSource on every request.
-
-        NB: We deliberately do not take the User off the request object as
-        sometimes we want to persist a LeadSource against a known user from
-        an unauthenticated request.
-        """
-        return LeadSource.objects.create(
-            user=user,
-            medium=request.session.pop("utm_medium"),
-            source=request.session.pop("utm_source"),
-            campaign=request.session.pop("utm_campaign", ""),
-            term=request.session.pop("utm_term", ""),
-            content=request.session.pop("utm_content", ""),
-        )
+        """Persist a LeadSource dictionary of utm_* values."""
+        try:
+            return LeadSource.objects.create(
+                user=user,
+                medium=utm_params["utm_medium"],
+                source=utm_params["utm_source"],
+                campaign=utm_params.get("utm_campaign", ""),
+                term=utm_params.get("utm_term", ""),
+                content=utm_params.get("utm_content", ""),
+            )
+        except KeyError as ex:
+            raise ValueError(f"Missing utm param: {ex}")
 
 
 class LeadSource(models.Model):

--- a/utm_tracker/session.py
+++ b/utm_tracker/session.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def stash_utm_params(session: SessionBase, params: UtmParamsDict) -> bool:
     """
-    Add a new utm_params dictionary to the session.
+    Add new utm_params to the list of utm_params in the session.
 
     If the params dict is empty ({}), then it is ignored.
 

--- a/utm_tracker/session.py
+++ b/utm_tracker/session.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, List
 
 from django.contrib.sessions.backends.base import SessionBase
@@ -6,6 +7,8 @@ from .models import LeadSource
 from .types import UtmParamsDict
 
 SESSION_KEY_UTM_PARAMS = "utm_params"
+
+logger = logging.getLogger(__name__)
 
 
 def stash_utm_params(session: SessionBase, params: UtmParamsDict) -> bool:
@@ -42,5 +45,8 @@ def flush_utm_params(user: Any, session: SessionBase) -> List[LeadSource]:
     """
     created = []
     for params in pop_utm_params(session):
-        created.append(LeadSource.objects.create_from_utm_params(user, params))
+        try:
+            created.append(LeadSource.objects.create_from_utm_params(user, params))
+        except ValueError as ex:
+            logger.debug(f"Unable to save utm_params: {params}: {ex}")
     return created

--- a/utm_tracker/session.py
+++ b/utm_tracker/session.py
@@ -32,7 +32,7 @@ def pop_utm_params(session: SessionBase) -> List[UtmParamsDict]:
     return session.pop(SESSION_KEY_UTM_PARAMS, [])
 
 
-def flush_utm_params(user: Any, session: SessionBase) -> List[LeadSource]:
+def dump_utm_params(user: Any, session: SessionBase) -> List[LeadSource]:
     """
     Flush utm_params from the session and save as LeadSource objects.
 

--- a/utm_tracker/types.py
+++ b/utm_tracker/types.py
@@ -1,0 +1,3 @@
+from typing import Dict
+
+UtmParamsDict = Dict[str, str]


### PR DESCRIPTION
Fixes #3 

This is a fairly significant refactoring of a lot of the internals, combined with some breaking changes to the externals.

In summary:

* The library now supports the 'stashing' of multiple utm_params in a session
* There is a new module `utm_tracker.session` that has the main non-model entry points
* There is a new function `flush_utm_params` which will create `LeadSource` objects for all params stored in the session

The lifecycle now looks like this:

1. On each request, any utm_params found are stored in the session using `stash_utm_params`
2. If the user is authenticated, the session is immediately flushed, creating a new LeadSource object
3. If the user is anonymous, the session is maintained, and the utm_params will stack up.

If you need to flush the session for a known user, e.g. as part of a registration flow, you should use `flush_utm_params`. This will handle the creation of LeadSource objects and the flushing of the session:

```python
def view(request):

    user = User.objects.create(...)
    
    # this will create LeadSource objects for the user and 
    # clear out the session
    flush_utm_params(user, request.session)
```

