### PR TITLE
Document app and middleware names more explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ def referral(request, token):
 
 ## Configuration
 
-Add the app to `INSTALLED_APPS`, and add both middleware classes to `MIDDLEWARE`.
+Add the `'utm_tracker'` app to `INSTALLED_APPS`, and add both middleware classes (`'utm_tracker.middleware.UtmSessionMiddleware'` and `'utm_tracker.middleware.LeadSourceMiddleware'`) to `MIDDLEWARE`.
 
 The `UtmSession` middleware must come before `LeadSource` middleware.


### PR DESCRIPTION
Had to go source diving for these. Figure I can save future people the extra 30 seconds.

(thanks for this lib by the way, seems to work great!)