### PR TITLE
Remove Django 2.2, 3.0 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8,"3.10"]
-        django: [31,40,main]
+        python: [3.7,"3.10"]
+        django: [22,31,40,main]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
-        django: [32,40,main]
+        python: [3.8,"3.10"]
+        django: [31,40,main]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         python: [3.7,"3.10"]
-        django: [22,31,40,main]
+        django: [31,40,main]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,12 @@ repos:
 
   # python code formatting - will amend files
   - repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
 
@@ -30,7 +30,7 @@ repos:
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.961
     hooks:
       - id: mypy
         additional_dependencies:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 yunojuno
+Copyright (c) 2022 yunojuno
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Django app for extracting and storing UTM tracking values.
 
 ## Django support
 
-This package support Django 3.2+, and Python 3.7+
+This package supports Django 3.1+, and Python 3.8+
+
+Previous supported version will be tagged in the repo, should you required them.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app for extracting and storing UTM tracking values.
 
 ## Django support
 
-This package supports Django 2.2+, and Python 3.7+
+This package supports Django 3.1+ (requires `JSONField`), and Python 3.7+.
 
 Previous supported version will be tagged in the repo, should you required them.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app for extracting and storing UTM tracking values.
 
 ## Django support
 
-This package supports Django 3.1+, and Python 3.8+
+This package supports Django 2.2+, and Python 3.7+
 
 Previous supported version will be tagged in the repo, should you required them.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,15 @@ documentation = "https://github.com/yunojuno/django-utm-tracker"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
+    "Framework :: Django :: 2.2",
+    "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -26,8 +28,8 @@ classifiers = [
 packages = [{include="utm_tracker"}]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-django = "^3.1 || ^4.0"
+python = "^3.7"
+django = "^2.2 || ^3.0 || ^4.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "*", allow-prereleases = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-utm-tracker"
-version = "1.2"
+version = "2.0"
 description = "Django app for extracting and storing UTM tracking values."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,15 +12,13 @@ documentation = "https://github.com/yunojuno/django-utm-tracker"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -28,8 +26,8 @@ classifiers = [
 packages = [{include="utm_tracker"}]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-django = "^2.2 || ^3.0 || ^4.0"
+python = "^3.8"
+django = "^3.1 || ^4.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "*", allow-prereleases = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ documentation = "https://github.com/yunojuno/django-utm-tracker"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
@@ -29,7 +27,7 @@ packages = [{include="utm_tracker"}]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-django = "^2.2 || ^3.0 || ^4.0"
+django = "^3.1 || ^4.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "*", allow-prereleases = true}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, py{3.8,3.9,3.10}-django{31,32,40,main}
+envlist = fmt, lint, mypy, py{3.7,3.8,3.9,3.10}-django{22,30,31,32,40,main}
 
 [testenv]
 deps =
@@ -8,6 +8,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
+    django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
@@ -36,7 +38,7 @@ commands =
 [testenv:lint]
 description = Python source code linting (flake8, bandit, pydocstyle)
 deps =
-    bandit==1.7.2
+    bandit
     flake8
     flake8-bandit
     flake8-blind-except

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, py{3.7,3.8,3.9,3.10}-django{22,30,31,32,40,main}
+envlist = fmt, lint, mypy, py{3.7,3.8,3.9,3.10}-django{31,32,40,main}
 
 [testenv]
 deps =
@@ -8,8 +8,6 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, py{3.7,3.8,3.9,3.10}-django{31,32,40,main}
+envlist = fmt, lint, mypy, py{3.8,3.9,3.10}-django{31,32,40,main}
 
 [testenv]
 deps =

--- a/utm_tracker/request.py
+++ b/utm_tracker/request.py
@@ -41,7 +41,8 @@ def parse_qs(request: HttpRequest) -> UtmParamsDict:
     }
 
     for ad_key in VALID_AD_PARAMS:
-        if akey := request.GET.get(ad_key):
+        akey = request.GET.get(ad_key)
+        if akey:
             # We don't want to lowercase the ad key, as they are
             # typically BASE64 encoded
             utm_keys[ad_key] = akey
@@ -49,7 +50,8 @@ def parse_qs(request: HttpRequest) -> UtmParamsDict:
     # add in any custom tags we have decided to stash
     for tag in CUSTOM_TAGS:
         # custom tags may be a list
-        if val := request.GET.getlist(tag):
+        val = request.GET.getlist(tag)
+        if val:
             utm_keys[tag] = ",".join(val)
 
     return utm_keys


### PR DESCRIPTION
Addresses #15 

The project classifiers, tox config, pyproject.toml and github actions were all out of sync. This issue was raised in #15 which pointed out that the use of `:=` in one function would break any Python 3.7 deployments. I have replaced their use with a pre-3.7 compatible equivalent.

I have removed Django 2.2 and 3.0 from the supported versions as the model requires `JSONField` which was brought in in 3.1. (Previously Postgres only.)
