### PR TITLE
Add support for Django 6.0 in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
@@ -28,7 +29,7 @@ packages = [{include="utm_tracker"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-django = "^4.2 || ^5.0"
+django = "^4.2 || ^5.0 || ^6.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "*"


### PR DESCRIPTION
Would be nice to be able to use this library with Django 6!

Note: I'm not 100% confident this is the only change needed as I can't trivially test the publish/upgrade workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Django 6.0 support by updating classifiers and expanding the `django` dependency to include `^6.0`.
> 
> - **Packaging (`pyproject.toml`)**:
>   - Add classifier `"Framework :: Django :: 6.0"`.
>   - Expand `django` dependency to `^4.2 || ^5.0 || ^6.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0bf05a0a3454243339abec44797b54f62741ac8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->